### PR TITLE
Update accurate version for Pre-Commit Hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ $ detect-secrets --scan > .secrets.baseline
 ```
 $ cat .pre-commit-config.yaml
 -   repo: git@github.com:yelp/detect-secrets
-    rev: v0.6.3
+    rev: 0.8.2
     hooks:
     -   id: detect-secrets
         args: ['--baseline', '.secrets.baseline']


### PR DESCRIPTION
In the Pre-Commit Hook YAML, `v0.6.3` is non-existent in this repository. Change it to `0.8.2` so that users can copy-and-paste the YAML file and get it to work.